### PR TITLE
WIP: Dependent resources

### DIFF
--- a/src/__tests__/integration/test.tsx
+++ b/src/__tests__/integration/test.tsx
@@ -39,6 +39,7 @@ const mockResource = {
   maxAge: 0,
   maxCache: Infinity,
   isBrowserOnly: false,
+  depends: null,
 };
 
 const historyBuildOptions = {
@@ -224,6 +225,7 @@ describe('<Router /> integration tests', () => {
           },
         },
       },
+      executing: null,
     });
   });
 });

--- a/src/__tests__/unit/controllers/resource-store/utils/dependent-resources/test.tsx
+++ b/src/__tests__/unit/controllers/resource-store/utils/dependent-resources/test.tsx
@@ -1,0 +1,585 @@
+import React from 'react';
+import { StoreActionApi } from 'react-sweet-state';
+import {
+  executeTuples,
+  executeForDependents,
+  getDependencies,
+  ResourceDependencyError,
+} from '../../../../../../controllers/resource-store/utils/dependent-resources';
+import {
+  ResourceType,
+  RouteResource,
+  RouteResourceResponseBase,
+} from '../../../../../../common/types';
+import { State } from '../../../../../../controllers/resource-store/types';
+import { createResource } from '../../../../../../controllers/resource-utils';
+
+describe('dependent resources', () => {
+  const mockRoute = {
+    name: 'foo',
+    path: '/foo',
+    component: () => <h1>test</h1>,
+    resources: [],
+  };
+  const mockMatch = {
+    params: {},
+    query: {},
+    isExact: false,
+    path: '',
+    url: '',
+  };
+  const mockRouterStoreContext = {
+    route: mockRoute,
+    match: mockMatch,
+    query: {},
+  };
+  const getKey = () => 'key';
+  const getData = () => {};
+
+  const toResource = (
+    type: ResourceType,
+    depends: ResourceType[] | undefined = undefined
+  ) => createResource({ type, depends, getKey, getData });
+
+  const resourceA = toResource('a');
+  const resourceB = toResource('b');
+
+  const resourceX = toResource('x');
+  const resourceY = toResource('y', ['x', 'y']); // depends on self too
+  const resourceZ = toResource('z', ['x', 'y']);
+
+  const createApi = (state: Partial<State>) => {
+    const currentState: Partial<State> = state;
+    const api: StoreActionApi<State> = {
+      getState: jest.fn(() => currentState) as () => State,
+      setState: jest.fn(v => {
+        Object.assign(currentState, v);
+      }) as (state: Partial<State>) => undefined,
+      dispatch: jest.fn(action => action(api, {})),
+    };
+
+    return api;
+  };
+
+  describe('executeTuples', () => {
+    it('should throw where there is existing executing state', () => {
+      const mockApi = createApi({ executing: [] });
+
+      expect(() => executeTuples([resourceA, resourceB], [])(mockApi)).toThrow(
+        'execution is already in progress'
+      );
+    });
+
+    it('should separately dispatch independent resources without creating executing state', () => {
+      const mockApi = createApi({ executing: null });
+      const action = jest.fn().mockReturnValueOnce(1).mockReturnValueOnce(2);
+
+      expect(
+        executeTuples(
+          [resourceA, resourceB],
+          [
+            [resourceA, action],
+            [resourceX, action],
+          ]
+        )(mockApi)
+      ).toEqual([1, 2]);
+
+      expect(mockApi.setState).not.toBeCalled();
+      expect(mockApi.dispatch).toHaveBeenCalledTimes(2);
+      expect(action).toBeCalledTimes(2);
+    });
+
+    it('should dispatch independent resources even if missing from current route', () => {
+      const mockApi = createApi({ executing: null });
+      const action = jest.fn().mockReturnValueOnce(1).mockReturnValueOnce(2);
+
+      expect(
+        executeTuples(
+          [],
+          [
+            [resourceA, action],
+            [resourceB, action],
+          ]
+        )(mockApi)
+      ).toEqual([1, 2]);
+
+      expect(mockApi.setState).not.toBeCalled();
+      expect(mockApi.dispatch).toHaveBeenCalledTimes(2);
+      expect(action).toBeCalledTimes(2);
+    });
+
+    it.each([
+      ['missing from current route resources', []],
+      ['current route resources are invalid (null)', null],
+      ['current route resources are invalid (undefined)', undefined],
+    ])(
+      'should dispatch independent resources even if %s',
+      (_label, routeResources) => {
+        const mockApi = createApi({ executing: null });
+        const action = jest.fn().mockReturnValueOnce(1).mockReturnValueOnce(2);
+
+        expect(
+          executeTuples(routeResources, [
+            [resourceA, action],
+            [resourceB, action],
+          ])(mockApi)
+        ).toEqual([1, 2]);
+
+        expect(mockApi.setState).not.toBeCalled();
+        expect(mockApi.dispatch).toHaveBeenCalledTimes(2);
+        expect(action).toBeCalledTimes(2);
+      }
+    );
+
+    it.each([
+      ['missing from current route resources', []],
+      ['current route resources are invalid (null)', null],
+      ['current route resources are invalid (undefined)', undefined],
+    ])(
+      'should dispatch dependent resources as independent if %s',
+      (_label, routeResources) => {
+        const mockApi = createApi({ executing: null });
+        const action = jest.fn().mockReturnValueOnce(1).mockReturnValueOnce(2);
+
+        expect(
+          executeTuples(routeResources, [
+            [resourceY, action],
+            [resourceZ, action],
+          ])(mockApi)
+        ).toEqual([1, 2]);
+
+        expect(mockApi.setState).not.toBeCalled();
+        expect(mockApi.dispatch).toHaveBeenCalledTimes(2);
+        expect(action).toBeCalledTimes(2);
+      }
+    );
+
+    it('should construct an executing state of executing resources and their dependencies', () => {
+      const mockApi = createApi({ executing: null });
+      const action = jest.fn().mockReturnValue(1);
+
+      expect(
+        executeTuples(
+          [resourceA, resourceB, resourceX, resourceY],
+          [[resourceY, action]]
+        )(mockApi)
+      ).toEqual([1]);
+
+      expect(mockApi.setState).toBeCalledTimes(2);
+      expect(mockApi.setState).toHaveBeenNthCalledWith(1, {
+        executing: [
+          [resourceX, null],
+          [resourceY, action],
+        ],
+      });
+      expect(mockApi.dispatch).toHaveBeenCalledTimes(1);
+      expect(action).toBeCalledTimes(1);
+      expect(mockApi.setState).toHaveBeenNthCalledWith(2, { executing: null });
+    });
+
+    it('should construct an executing state of executing resources and their dependents', () => {
+      const mockApi = createApi({ executing: null });
+      const action = jest.fn().mockReturnValue(1);
+
+      expect(
+        executeTuples(
+          [resourceA, resourceB, resourceX, resourceY],
+          [[resourceX, action]]
+        )(mockApi)
+      ).toEqual([1]);
+
+      expect(mockApi.setState).toBeCalledTimes(2);
+      expect(mockApi.setState).toHaveBeenNthCalledWith(1, {
+        executing: [
+          [resourceX, action],
+          [resourceY, null],
+        ],
+      });
+      expect(mockApi.dispatch).toHaveBeenCalledTimes(1);
+      expect(action).toBeCalledTimes(1);
+      expect(mockApi.setState).toHaveBeenNthCalledWith(2, { executing: null });
+    });
+
+    it('should presume execution mutates executing state and dispatch action from most recent state', () => {
+      const mockApi = createApi({ executing: null });
+      const action2 = jest.fn().mockReturnValue(2);
+      const action1 = jest.fn(() => {
+        mockApi.setState({
+          executing: [
+            [resourceX, action1],
+            [resourceY, action2],
+          ],
+        });
+
+        return 1;
+      });
+
+      expect(
+        executeTuples(
+          [resourceA, resourceB, resourceX, resourceY],
+          [[resourceX, action1]]
+        )(mockApi)
+      ).toEqual([1]);
+
+      expect(mockApi.setState).toBeCalledTimes(3);
+      expect(mockApi.setState).toHaveBeenNthCalledWith(1, {
+        executing: [
+          [resourceX, action1],
+          [resourceY, null],
+        ],
+      });
+      expect(mockApi.setState).toHaveBeenNthCalledWith(2, {
+        executing: [
+          [resourceX, action1],
+          [resourceY, action2],
+        ],
+      });
+      expect(mockApi.dispatch).toHaveBeenCalledTimes(2);
+      expect(action1).toBeCalledTimes(1);
+      expect(action2).toBeCalledTimes(1);
+      expect(mockApi.setState).toHaveBeenNthCalledWith(3, { executing: null });
+    });
+
+    it('should remove execution state and throw if executing state is mutated inconsistently', () => {
+      const mockApi = createApi({ executing: null });
+      const action2 = jest.fn().mockReturnValue(2);
+      const action1 = jest.fn(() => {
+        mockApi.setState({
+          executing: [
+            [resourceX, action1],
+            [resourceZ, action2],
+          ],
+        });
+
+        return 1;
+      });
+
+      expect(() =>
+        executeTuples(
+          [resourceA, resourceB, resourceX, resourceY],
+          [[resourceX, action1]]
+        )(mockApi)
+      ).toThrow('execution reached an inconsistent state');
+
+      expect(mockApi.setState).toBeCalledTimes(3);
+      expect(mockApi.setState).toHaveBeenNthCalledWith(1, {
+        executing: [
+          [resourceX, action1],
+          [resourceY, null],
+        ],
+      });
+      expect(mockApi.setState).toHaveBeenNthCalledWith(2, {
+        executing: [
+          [resourceX, action1],
+          [resourceZ, action2],
+        ],
+      });
+      expect(mockApi.dispatch).toHaveBeenCalledTimes(1);
+      expect(action1).toBeCalledTimes(1);
+      expect(action2).not.toBeCalled();
+      expect(mockApi.setState).toHaveBeenNthCalledWith(3, { executing: null });
+    });
+
+    it('should execute independent and dependent resources separately regardless of given tuple order', () => {
+      const mockApi = createApi({ executing: null });
+      const action = jest
+        .fn()
+        .mockReturnValueOnce(1)
+        .mockReturnValueOnce(2)
+        .mockReturnValueOnce(3)
+        .mockReturnValueOnce(4);
+
+      expect(
+        executeTuples(
+          [resourceA, resourceB, resourceX, resourceY],
+          [
+            [resourceA, action],
+            [resourceX, action],
+            [resourceB, action],
+            [resourceY, action],
+          ]
+        )(mockApi)
+      ).toEqual([1, 3, 2, 4]);
+    });
+  });
+
+  describe('executeForDependents', () => {
+    it('should do nothing outside of executing state', () => {
+      const mockApi = createApi({ executing: null });
+      const actionCreator = jest.fn().mockReturnValueOnce(1);
+
+      executeForDependents(resourceX, actionCreator)(mockApi);
+
+      expect(mockApi.getState).toBeCalled();
+      expect(mockApi.setState).not.toBeCalled();
+      expect(actionCreator).not.toBeCalled();
+    });
+
+    it('should do nothing where given resource is not executing', () => {
+      const mockApi = createApi({
+        executing: [
+          [resourceY, null],
+          [resourceZ, null],
+        ],
+      });
+      const actionCreator = jest.fn().mockReturnValue(1);
+
+      executeForDependents(resourceX, actionCreator)(mockApi);
+
+      expect(mockApi.getState).toBeCalled();
+      expect(mockApi.setState).not.toBeCalled();
+      expect(actionCreator).not.toBeCalled();
+    });
+
+    it('should revise action for resources in executing state dependent on the given resource', () => {
+      const mockApi = createApi({
+        executing: [
+          [resourceX, null],
+          [resourceY, null],
+          [resourceZ, null],
+        ],
+      });
+      const actionCreator = jest
+        .fn()
+        .mockReturnValueOnce(1)
+        .mockReturnValueOnce(2);
+
+      executeForDependents(resourceX, actionCreator)(mockApi);
+
+      expect(mockApi.getState).toBeCalled();
+      expect(mockApi.setState).toBeCalledWith({
+        executing: [
+          [resourceX, null],
+          [resourceY, 1],
+          [resourceZ, 2],
+        ],
+      });
+      expect(actionCreator).toBeCalledTimes(2);
+      expect(actionCreator).toHaveBeenNthCalledWith(1, resourceY);
+      expect(actionCreator).toHaveBeenNthCalledWith(2, resourceZ);
+    });
+
+    it('should not revise action for itself where given resource is a self dependent', () => {
+      const mockApi = createApi({
+        executing: [
+          [resourceX, null],
+          [resourceY, null],
+        ],
+      });
+      const actionCreator = jest.fn().mockReturnValue(1);
+
+      executeForDependents(resourceY, actionCreator)(mockApi);
+
+      expect(mockApi.getState).toBeCalled();
+      expect(mockApi.setState).toBeCalledWith({
+        executing: [
+          [resourceX, null],
+          [resourceY, null],
+        ],
+      });
+      expect(actionCreator).not.toHaveBeenCalled();
+    });
+
+    it('should not revise action for resources preceding the given resource in executing state', () => {
+      const mockApi = createApi({
+        executing: [
+          [resourceZ, null],
+          [resourceX, null],
+          [resourceY, null],
+        ],
+      });
+      const actionCreator = jest.fn().mockReturnValue(1);
+
+      executeForDependents(resourceX, actionCreator)(mockApi);
+
+      expect(mockApi.getState).toBeCalled();
+      expect(mockApi.setState).toBeCalledWith({
+        executing: [
+          [resourceZ, null],
+          [resourceX, null],
+          [resourceY, 1],
+        ],
+      });
+      expect(actionCreator).toBeCalledTimes(1);
+      expect(actionCreator).toBeCalledWith(resourceY);
+    });
+  });
+
+  describe('getDependencies', () => {
+    const slice1 = { data: 1 } as RouteResourceResponseBase<number>;
+    const slice2 = { data: 2 } as RouteResourceResponseBase<number>;
+
+    it('should return empty object where given resource has no dependencies', () => {
+      const mockApi = createApi({ executing: [] });
+
+      expect(
+        getDependencies(
+          { depends: null } as RouteResource,
+          mockRouterStoreContext
+        )(mockApi)
+      ).toEqual({});
+
+      expect(
+        getDependencies(
+          { depends: [] as ResourceType[] } as RouteResource,
+          mockRouterStoreContext
+        )(mockApi)
+      ).toEqual({});
+
+      expect(mockApi.getState).not.toBeCalled();
+    });
+
+    it('should return null where called outside of executing state', () => {
+      const mockApi = createApi({ executing: null });
+
+      expect(() =>
+        getDependencies(resourceY, mockRouterStoreContext)(mockApi)
+      ).toThrow(
+        new ResourceDependencyError(
+          'Missing resource: "y" has dependencies so must not be missing'
+        )
+      );
+
+      expect(mockApi.getState).toBeCalled();
+    });
+
+    it('should throw ResourceDependencyError where given dependent resource is not in executing state', () => {
+      const mockApi = createApi({
+        executing: [
+          [resourceX, null],
+          [resourceY, null],
+        ],
+      });
+
+      expect(() =>
+        getDependencies(resourceZ, mockRouterStoreContext)(mockApi)
+      ).toThrow(
+        new ResourceDependencyError(
+          'Missing resource: "z" has dependencies so must not be missing'
+        )
+      );
+
+      expect(mockApi.getState).toBeCalled();
+    });
+
+    it('should throw ResourceDependencyError for first dependency missing from executing state', () => {
+      const mockApi = createApi({
+        data: {
+          x: { key: slice1 },
+          y: { key: slice2 },
+        },
+        executing: [
+          [resourceX, null],
+          [resourceY, null],
+        ],
+      });
+
+      expect(() =>
+        getDependencies(
+          { ...resourceY, depends: ['a', 'b'] } as RouteResource,
+          mockRouterStoreContext
+        )(mockApi)
+      ).toThrow(
+        new ResourceDependencyError(
+          'Missing resource: "y" depends "a" which is missing'
+        )
+      );
+
+      expect(() =>
+        getDependencies(
+          { ...resourceY, depends: ['a', 'x'] } as RouteResource,
+          mockRouterStoreContext
+        )(mockApi)
+      ).toThrow(
+        new ResourceDependencyError(
+          'Missing resource: "y" depends "a" which is missing'
+        )
+      );
+
+      expect(() =>
+        getDependencies(
+          { ...resourceY, depends: ['y', 'b'] } as RouteResource,
+          mockRouterStoreContext
+        )(mockApi)
+      ).toThrow(
+        new ResourceDependencyError(
+          'Missing resource: "y" depends "b" which is missing'
+        )
+      );
+
+      expect(mockApi.getState).toBeCalled();
+      expect(mockApi.setState).not.toBeCalled();
+    });
+
+    it('should return {type:slice} for dependencies preceding given resource in executing state', () => {
+      const mockApi = createApi({
+        data: {
+          x: { key: slice1 },
+          y: { key: slice2 },
+        },
+        executing: [
+          [resourceX, null],
+          [resourceY, null],
+          [resourceZ, null],
+        ],
+      });
+
+      expect(
+        getDependencies(resourceZ, mockRouterStoreContext)(mockApi)
+      ).toEqual({
+        x: slice1,
+        y: slice2,
+      });
+
+      expect(mockApi.getState).toBeCalled();
+      expect(mockApi.setState).not.toBeCalledWith({});
+    });
+
+    it('should return {type:own-slice} where given resource is self dependent', () => {
+      const mockApi = createApi({
+        data: {
+          x: { key: slice1 },
+          y: { key: slice2 },
+        },
+        executing: [
+          [resourceX, null],
+          [resourceY, null],
+        ],
+      });
+
+      expect(
+        getDependencies(resourceY, mockRouterStoreContext)(mockApi)
+      ).toEqual({
+        x: slice1,
+        y: slice2,
+      });
+
+      expect(mockApi.getState).toBeCalled();
+      expect(mockApi.setState).not.toBeCalled();
+    });
+
+    it('should throw ResourceDependencyError for first dependency following given resource in executing state', () => {
+      const mockApi = createApi({
+        data: {
+          x: { key: slice1 },
+          y: { key: slice2 },
+        },
+        executing: [
+          [resourceY, null],
+          [resourceX, null],
+        ],
+      });
+
+      expect(() =>
+        getDependencies(resourceY, mockRouterStoreContext)(mockApi)
+      ).toThrow(
+        new ResourceDependencyError(
+          'Illegal dependency: "y" depends "x" so "x" must precede "y"'
+        )
+      );
+
+      expect(mockApi.getState).toBeCalled();
+      expect(mockApi.setState).not.toBeCalled();
+    });
+  });
+});

--- a/src/__tests__/unit/controllers/resource-utils/test.ts
+++ b/src/__tests__/unit/controllers/resource-utils/test.ts
@@ -17,6 +17,7 @@ describe('resource utils', () => {
         maxAge: 0,
         maxCache: DEFAULT_CACHE_MAX_LIMIT,
         isBrowserOnly: false,
+        depends: null,
       });
     });
 
@@ -37,6 +38,7 @@ describe('resource utils', () => {
         maxAge: 0,
         maxCache: DEFAULT_CACHE_MAX_LIMIT,
         isBrowserOnly: false,
+        depends: null,
       });
 
       await resource.getData(routerContext, {});
@@ -58,6 +60,7 @@ describe('resource utils', () => {
         maxAge: 400,
         maxCache: DEFAULT_CACHE_MAX_LIMIT,
         isBrowserOnly: false,
+        depends: null,
       });
     });
 
@@ -77,6 +80,7 @@ describe('resource utils', () => {
         maxAge: 0,
         maxCache: 3,
         isBrowserOnly: false,
+        depends: null,
       });
     });
 
@@ -97,6 +101,7 @@ describe('resource utils', () => {
         maxAge: 0,
         maxCache: 3,
         isBrowserOnly: true,
+        depends: null,
       });
     });
   });

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -152,7 +152,10 @@ export type RouteResourceResponse<
     | RouteResourceResponseLoaded<RouteResourceData>
   );
 
-export type RouterDataContext = RouterContext & ResourceFetchContext;
+export type RouterDataContext = RouterContext & {
+  isPrefetch: boolean;
+  dependencies: ResourceDependencies;
+};
 
 export type UseResourceHookResponse<RouteResourceData> = RouteResourceResponse<
   RouteResourceData
@@ -163,15 +166,10 @@ export type UseResourceHookResponse<RouteResourceData> = RouteResourceResponse<
   clearAll: () => void;
 };
 
-export type RouteResourceGettersArgs = [
-  RouterDataContext,
-  ResourceStoreContext
-];
-
 export type ResourceType = string;
 export type ResourceKey = string;
 
-export type RouteResource<RouteResourceData extends unknown = unknown> = {
+export type RouteResource<T extends unknown = unknown> = {
   type: ResourceType;
   getKey: (
     routerContext: RouterContext,
@@ -181,9 +179,10 @@ export type RouteResource<RouteResourceData extends unknown = unknown> = {
   getData: (
     routerContext: RouterDataContext,
     customContext: ResourceStoreContext
-  ) => RouteResourceData | Promise<RouteResourceData>;
+  ) => T | Promise<T>;
   maxCache: number;
   isBrowserOnly: boolean;
+  depends: ResourceType[] | null;
 };
 
 export type RouteResources = RouteResource[];
@@ -204,8 +203,8 @@ export type RouterContext = {
   query: Query;
 };
 
-export type ResourceFetchContext = {
-  isPrefetch: boolean;
+export type ResourceDependencies = {
+  [type: string]: RouteResourceResponse;
 };
 
 /**

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -13,8 +13,16 @@ export {
   useQueryParam,
   usePathParam,
 } from './hooks';
-export { useResourceStoreContext } from './resource-store';
+export {
+  useResourceStoreContext,
+  ResourceDependencyError,
+} from './resource-store';
 export { createResource } from './resource-utils';
+export type {
+  CreateResourceArgBase,
+  CreateResourceArgSync,
+  CreateResourceArgAsync,
+} from './resource-utils';
 export {
   RouteResourceEnabledSubscriber,
   createRouterSelector,

--- a/src/controllers/resource-store/types.ts
+++ b/src/controllers/resource-store/types.ts
@@ -11,9 +11,13 @@ import {
   RouterContext,
 } from '../../common/types';
 
+export type ExecutionTuple = [RouteResource, ResourceAction<any>];
+export type ExecutionMaybeTuple = [RouteResource, ResourceAction<any> | null];
+
 export type State = {
   data: ResourceStoreData;
   context: ResourceStoreContext;
+  executing: ExecutionMaybeTuple[] | null;
 };
 
 export type HydratableState = {

--- a/src/controllers/resource-store/utils/dependent-resources/README.md
+++ b/src/controllers/resource-store/utils/dependent-resources/README.md
@@ -1,0 +1,255 @@
+# Dependent Resources
+
+Dependent resources allows relationships between resources that exist is some well defined list,
+such as the route resources list.
+
+## Definitions
+
+A resource that has `depends` field is said to be a "dependent resource". It is dependent on the
+value of the resource types listed in its `depends` field. It cannot execute its `getData()`
+function unless those other resources are present. Its `getData()` has access a `dependencies` hash
+containing the current slice of each of those resources.
+
+Resources that exist in some dependent resource's `depends` list are said to be "dependency
+resources". They are a normal resources in all respects except that they need to execute
+their `getData()` function first, before that of the dependent resources.
+
+Together the "dependent resources" and their "dependency resources" are said to be "interrelated
+resources".
+
+Resources that are not related to any other resources are said to be an "independent resource".
+
+Resources that don't appear in the list of resources are said to be an "unlisted resource".
+
+## Rules
+
+To avoid circular dependencies we impose the following rules.
+
+- There must be a well defined list of resources (typically the route resource list)
+- Resources with dependencies _must_ appear in the resource list.
+- Resources may depend on any resource that _precedes_ it in the resource list.
+- Resources may depend on themself in order for their `getData()` to access their previous value.
+- Unlisted resources cannot contain dependencies.
+- Independent resources may execute out of listed order.
+
+If a resource uses `depends` contrary to these rules its `getData()` will **not** be called and it
+will fail with `error: ResourceDependencyError`.
+
+Any resource that omits `depends` cannot fail due to dependencies that exist elsewere.
+
+## Actions
+
+By design, certain Resource Store actions on dependency resources will have side effects on
+dependent resources.
+
+| dependency action | where dependency               | dependent side-effect |
+| ----------------- | ------------------------------ | --------------------- |
+| clear             |                                | clear                 |
+| refresh           | getData() returns new value    | refresh               |
+| refresh           | getData() returns promise      | refresh               |
+| refresh           | getData() returns prev value   | -                     |
+| update            | updaterFn() returns new value  | refresh               |
+| update            | updaterFn() returns prev value | -                     |
+
+Note that should a resource `depends` on itself and its `getData()` return the previous value by
+reference, then returning the previous data will avoid any dependency side-effects.
+
+Similarly an `update()` where `updaterFn` returns the value it was given will not produce
+dependency side-effects.
+
+## Internal Operation
+
+In this section we will discuss the following example.
+
+**Example** - route resources A-F, excluding X
+
+```
+ ROUTE RESOURCES                               UNLISTED
+         ┌───────────────────────┐
+         │                       │
+ ┌───┐ ┌─▼─┐ ┌───┐ ┌───┐ ┌───┐ ┌─┴─┐           ┌───┐
+ │   │ │   │ │   │ │   │ │   │ │   │           │   │
+ │ A │ │ B │ │ C │ │ D │ │ E │ │ F │           │ X │
+ │   │ │   │ │   │ │   │ │   │ │   │           │   │
+ └▲─▲┘ └───┘ └─┬─┘ └─┬─┘ └───┘ └───┘           └───┘
+  │ │          │     │
+  │ └──────────┘     │
+  │                  │
+  └──────────────────┘
+```
+
+In this example we have
+
+- 2 sets of interrelated resource `A,C,D` and `B,F`
+- independent resource `E`
+- some unlisted resource `X`
+
+We can execute actions on independent or unlisted resources `E,X` at any time and in any order since
+they are not interrelated with any other resources. So long as `X` omits `depends` it will operate
+correctly. But for all the interrelated resources we must execute actions in the route resource
+order.
+
+For example, in executing an explicit "update" action on `A` we need to somehow "refresh"
+dependencies `C,D`. To do this we create an ordered "executing state" were we first say "execute
+update A" but allow the addition of "execute refresh C", "execute refresh D" as side-effects.
+
+The `executing` state is a list of interrelated resources and actions, implemented as
+`[RouteResource, ResourceStoreAction]` tuples. When we want to explicitly execute an action we
+pass a similar tuple to the `executeTuples()` method.
+
+Resource store actions that may produce dependency side-effects must be wrapped in
+`actionWithDependencies()` or `mapActionWithDependencies()` such that they will generate tuples. The
+actual concrete implementation of these actions must some private action that is **not** wrapped in
+`withDependencies()`.
+
+Any such private action that is dispatched while `executing` state is in place may call
+
+- `executeForDepenents()` to effect any dependent resources.
+- `getDependencies()` to get resource store data for their own dependencies.
+
+### Executing state includes interrelated resources
+
+All interrelated resources downstream from explicit execution need to be included in `executing`
+state.
+
+**Example** - Executing "update A"
+
+Public `updateResourceState` action calls `executeTuples([[ ResourceA, updateResourceState ]])`
+which sets initial `executing` state.
+
+```javascript
+ ▼
+[[ResourceA, updateResourceState], [ResourceC, null], [ResourceD, null]]
+```
+
+Note that the `executing` state
+
+- needs to only include resources that are interrelated and downstream for those executing, `B,F`
+  may be omitted.
+- includes placeholder `null` actions for resources not explicitly executing.
+
+The `executing` state is iterated synchronously and the private actions it contains are dispatched.
+
+Iteration first dispatches whatever action is present for `A`.
+
+Update of `A` calls `executeForDependents(ResourceA, getResourceFromRemote)` which overrides actions
+for `C,D`.
+
+```javascript
+             ▼
+[[ResourceA, updateResourceState], [ResourceC, getResourceFromRemote], [ResourceD, getResourceFromRemote]]
+```
+
+Iteration moves forward and dispatches whatever action is present for `C`.
+
+Refresh of `C` calls `executeForDependents(ResourceC, updateResourceState)` but there are do dependents of `C`.
+
+```javascript
+                                               ▼
+[[ResourceA, updateResourceState], [ResourceC, getResourceFromRemote], [ResourceD, getResourceFromRemote]]
+```
+
+Iteration moves forward and dispatches whatever action is present for `D`.
+
+Refresh of `D` has no side-effects.
+
+```javascript
+                                                                                   ▼
+[[ResourceA, updateResourceState], [ResourceC, getResourceFromRemote], [ResourceD, getResourceFromRemote]]
+```
+
+With iteration complete we reset `executing` state.
+
+```
+null
+```
+
+### Executing state includes dependency resources
+
+In order to validate dependencies we need to include all direct dependencies in `executing` state.
+
+**Example** - Executing "refresh F"
+
+Public update action calls `executeTuples([[ResourceD, getResourceFromRemote]])` which sets initial `executing`
+state.
+
+```javascript
+ ▼
+[[ ResourceA, null ], [ ResourceD, getResourceFromRemote ]]
+```
+
+Note that the `executing` state
+
+- includes `A` as dependency of `D` even though it is not executing.
+- includes placeholder `null` actions for resources not explicitly executing.
+
+The `executing` state is iterated synchronously and the private actions it contains are dispatched.
+
+Iteration first reaches `A` and finds there is nothing to dispatch.
+
+```javascript
+              ▼
+[[ ResourceA, null ], [ ResourceD, getResourceFromRemote ]]
+```
+
+Iteration then reaches `D` and dispatches whatever action is present for `D`.
+
+Refresh of `D` has no side-effects.
+
+```javascript
+                                   ▼
+[[ ResourceA, null ], [ ResourceD, getResourceFromRemote ]]
+```
+
+During refresh of `D` the `getDependencies(ResourceD)` function is called. Since `D` depends `A` and
+`A` precedes `D` in the `executing` state then we know it is a valid dependency.
+
+With iteration complete we reset `executing` state.
+
+```
+null
+```
+
+### Independent resources execute out-of-order
+
+Independent resources are omitted from `executing` state. We first iterate dependent resources and
+then follow up any independent resources that have not been executed. In this way resources can
+execute in a different order to how they appear in the resource list.
+
+**Example** - Executing "get all resources"
+
+Public `requestResources` action calls `executeTuples([[ResourceA, getResourceFromRemote], ...])`
+for all resources which sets initial `executing` state.
+
+```javascript
+ ▼
+[[ ResourceA, getResourceFromRemote ], ..., [ ResourceD, getResourceFromRemote ], [ ResourceF, getResourceFromRemote ]]
+```
+
+Note that the `executing` state
+
+- omits `E` since it is an independent resource
+
+Iteration first dispatches whatever action is present for `A`.
+
+Update of `A` calls `executeForDependents(ResourceA, getResourceFromRemote)` which overrides actions
+for `C,D`.
+
+```javascript
+             ▼
+[[ResourceA, updateResourceState], ..., [ResourceC, getResourceFromRemote], [ResourceD, getResourceFromRemote], ...]
+```
+
+Note`C,D` already have actions in place and we simply overwrite them with the new action. As it
+happens the overwritten action is the same.
+
+We will ignore the remaining iteration since it precedes in a similar fashion.
+
+With iteration complete we reset `executing` state.
+
+```
+null
+```
+
+At this time we find that the tuple `[ResourceE, updateResourceState]` has not yet been executed
+so we do so.

--- a/src/controllers/resource-store/utils/dependent-resources/index.ts
+++ b/src/controllers/resource-store/utils/dependent-resources/index.ts
@@ -1,18 +1,219 @@
-import { RouteResource } from '../../../../common/types';
-import { ResourceAction } from '../../types';
+import {
+  RouteResource,
+  ResourceDependencies,
+  RouterContext,
+  ResourceType,
+} from '../../../../common/types';
+import {
+  ExecutionTuple,
+  ExecutionMaybeTuple,
+  ResourceAction,
+} from '../../types';
+import { getSliceForResource } from '../../selectors';
+
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries
+const fromEntries =
+  Object.fromEntries ??
+  (<T>(entries: [string, T][]) =>
+    Object.assign({}, ...entries.map(([k, v]) => ({ [k]: v }))));
+
+type MatchableType =
+  | { type: ResourceType }
+  | RouteResource
+  | ExecutionTuple
+  | ExecutionMaybeTuple;
+const matchType = (a: MatchableType) => (b: MatchableType) => {
+  const [{ type: typeA }] = Array.isArray(a) ? a : [a];
+  const [{ type: typeB }] = Array.isArray(b) ? b : [b];
+
+  return typeA === typeB;
+};
+
+export class ResourceDependencyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ResourceDependencyError';
+  }
+}
+
+export const executeTuples = <R>(
+  routeResources: RouteResource[] | null | undefined,
+  tuples: ExecutionTuple[]
+): ResourceAction<R[]> => ({ getState, setState, dispatch }) => {
+  if (getState().executing) {
+    throw new Error('execution is already in progress');
+  }
+
+  // we cannot execute dependencies without route resources, regardless of whether tuple resource specifies dependency
+  const hasExecutableDependency =
+    routeResources?.some(({ depends }) => depends?.length) ?? false;
+
+  // optimise for no dependencies
+  if (!hasExecutableDependency) {
+    return tuples.map(([, action]) => dispatch(action));
+  }
+
+  // find all the resources on the route that have dependencies or are depended upon
+  // this potentially larger than needed since it is not specific to the resource being
+  // executed but its cheaper than analysing dependencies properly
+  // removing duplicates is not essential but helps debugging
+  const interdependentRouteResourceTypes = routeResources!
+    .reduceRight(
+      (acc, { type, depends }) => (depends ? [...acc, type, ...depends] : acc),
+      [] as ResourceType[]
+    )
+    .filter((v, i, a) => a.indexOf(v) === i);
+
+  // simply dispatch actions for independent resources
+  const independentTuples = tuples.filter(
+    ([{ type }]) => !interdependentRouteResourceTypes?.includes(type)
+  );
+  const independentResults = independentTuples.map(([, action]) =>
+    dispatch(action)
+  );
+
+  // complete without entering executing state where possible
+  if (independentTuples.length === tuples.length) {
+    return independentResults;
+  }
+
+  // setup executing tuples in route resource order just for the interdependent resources
+  // this state allows actions to call executeForDependents() to influence actions that follow
+  // we don't include independent resources to help debugging routes with many resources but sparse dependencies
+  // the list includes non-executing resources so that getDependencies() may validate without needing route resources
+  // we use the resource definition of the given tuple where present otherwise use the definition from route resource
+  const executingTuples: ExecutionMaybeTuple[] = routeResources!
+    .filter(({ type }) => interdependentRouteResourceTypes.includes(type))
+    .map(resource => tuples.find(matchType(resource)) ?? [resource, null]);
+
+  setState({ executing: executingTuples });
+
+  // dispatch sequentially during which executeForDependents() can cause tuples to change
+  const executedResults = executingTuples.map(([{ type: expectedType }], i) => {
+    const latestTuple = getState().executing?.[i];
+    const [{ type: latestType }, maybeAction] = latestTuple ?? [{}];
+
+    if (latestType !== expectedType) {
+      setState({ executing: null });
+      throw new Error('execution reached an inconsistent state');
+    }
+
+    return maybeAction ? dispatch(maybeAction) : undefined;
+  });
+
+  setState({ executing: null });
+
+  // combine results
+  const allTuples = [...independentTuples, ...executingTuples];
+  const allResults = [...independentResults, ...executedResults];
+
+  return tuples.map(
+    ([resource]) => allResults[allTuples.findIndex(matchType(resource))]
+  );
+};
 
 export const actionWithDependencies = <R extends unknown>(
-  _routeResources: RouteResource[] | undefined,
-  _resource: RouteResource,
+  routeResources: RouteResource[] | undefined,
+  resource: RouteResource,
   action: ResourceAction<R>
 ): ResourceAction<R> => ({ dispatch }) =>
-  // stub for future use
-  dispatch(action);
+  dispatch(
+    executeTuples<R>(routeResources, [[resource, action]])
+  )[0];
 
 export const mapActionWithDependencies = <R extends unknown>(
-  _routeResources: RouteResource[] | undefined,
+  routeResources: RouteResource[] | undefined,
   resources: RouteResource[],
   actionCreator: (resource: RouteResource) => ResourceAction<R>
-): ResourceAction<R[]> => ({ dispatch }) =>
-  // stub for future use
-  resources.map(resource => dispatch(actionCreator(resource)));
+): ResourceAction<R[]> =>
+  executeTuples<R>(
+    routeResources,
+    resources.map(resource => [resource, actionCreator(resource)])
+  );
+
+export const executeForDependents = <R extends unknown>(
+  resource: RouteResource,
+  actionCreator: (resource: RouteResource) => ResourceAction<R>
+): ResourceAction<void> => ({ getState, setState }) => {
+  const { executing: tuples } = getState();
+
+  // find the given resource in the currently executing tuples
+  const indexForResource = tuples?.findIndex(matchType(resource)) ?? -1;
+  if (indexForResource < 0) {
+    return;
+  }
+
+  // find dependent resources following given resource and revise their action
+  const executing = tuples!.map(
+    (tuple, i): ExecutionMaybeTuple => {
+      const [tupleResource] = tuple;
+
+      return i > indexForResource &&
+        tupleResource.depends?.includes(resource.type)
+        ? [tupleResource, actionCreator(tupleResource)]
+        : tuple;
+    }
+  );
+
+  setState({ executing });
+};
+
+export const getDependencies = (
+  resource: RouteResource,
+  routerStoreContext: RouterContext
+): ResourceAction<ResourceDependencies> => ({ getState }) => {
+  const { type, depends } = resource;
+
+  // optimise the case of no dependencies
+  if (!depends?.length) {
+    return {};
+  }
+
+  const { executing: tuples, data, context: resourceStoreContext } = getState();
+
+  // dependent resource cannot be called outside execution state
+  // find the given resource type in the currently executing tuples
+  const indexForResource = tuples?.findIndex(matchType(resource)) ?? -1;
+  if (indexForResource < 0) {
+    throw new ResourceDependencyError(
+      `Missing resource: "${type}" has dependencies so must not be missing`
+    );
+  }
+
+  // find tuples index for all the dependency elements
+  const dependencyIndexTuples = depends.map(
+    dependency =>
+      [dependency, tuples!.findIndex(matchType({ type: dependency }))] as const
+  );
+
+  // we rely on executing tuples including all dependencies of the caller resource
+  dependencyIndexTuples.forEach(([dependency, index]) => {
+    if (index < 0) {
+      throw new ResourceDependencyError(
+        `Missing resource: "${type}" depends "${dependency}" which is missing`
+      );
+    }
+    if (index > indexForResource) {
+      throw new ResourceDependencyError(
+        `Illegal dependency: "${type}" depends "${dependency}" so "${dependency}" must precede "${type}"`
+      );
+    }
+  });
+
+  return fromEntries(
+    dependencyIndexTuples.map(([dependency, index]) => {
+      const [{ getKey }] = tuples![index];
+
+      return [
+        dependency,
+        getSliceForResource(
+          { data },
+          {
+            type: dependency,
+            key: getKey(routerStoreContext, resourceStoreContext),
+          }
+        ),
+      ];
+    })
+  );
+};

--- a/src/controllers/resource-store/utils/index.ts
+++ b/src/controllers/resource-store/utils/index.ts
@@ -17,7 +17,10 @@ export {
   setResourceState,
 } from './manage-resource-state';
 export {
+  ResourceDependencyError,
   actionWithDependencies,
   mapActionWithDependencies,
+  executeForDependents,
+  getDependencies,
 } from './dependent-resources';
 export { toPromise } from './to-promise';

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -15,6 +15,7 @@ import type {
   Route,
   RouteContext,
   RouterActionsType,
+  ResourceType,
   RouteResourceBase,
   GetData,
   RouteResource,
@@ -88,6 +89,7 @@ declare export function useResource<T>(
 declare export function useRouter(): [RouterState, RouterActionsType];
 declare export function useRouterActions(): RouterActionsType;
 declare export function useResourceStoreContext(): ResourceStoreContext;
+declare export class ResourceDependencyError extends Error {}
 declare export function createRouterSelector<T, U = void>(
   selector: (state: RouterState, props: U) => T
 ): U => T;
@@ -145,21 +147,27 @@ type GetDataLoader<T> = () => Promise<{
  * Utility method to created type safe resources with defaults.
  *
  */
-type CreateResourceArg<T> =
-  | {|
-      ...RouteResourceBase,
-      getData: GetData<T>,
-      maxAge?: number,
-      maxCache?: number,
-      isBrowserOnly?: boolean,
-    |}
-  | {|
-      ...RouteResourceBase,
-      getDataLoader: GetDataLoader<T>,
-      maxAge?: number,
-      maxCache?: number,
-      isBrowserOnly?: boolean,
-    |};
+export type CreateResourceArgBase = {|
+  ...RouteResourceBase,
+  maxAge?: number,
+  maxCache?: number,
+  isBrowserOnly?: boolean,
+  depends?: ResourceType[],
+|};
+
+export type CreateResourceArgSync<T> = {|
+  ...CreateResourceArgBase,
+  getData: GetData<T>,
+|};
+
+export type CreateResourceArgAsync<T> = {|
+  ...CreateResourceArgBase,
+  getDataLoader: GetDataLoader<T>,
+|};
+
+export type CreateResourceArg<T> =
+  | CreateResourceArgSync<T>
+  | CreateResourceArgAsync<T>;
 
 declare export function createResource<T>(
   args: CreateResourceArg<T>

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,12 +15,18 @@ export {
   useQueryParam,
   usePathParam,
   useResourceStoreContext,
+  ResourceDependencyError,
   createResource,
   useRouterActions,
   createRouterSelector,
 } from './controllers';
 
-export type { WithRouter } from './controllers';
+export type {
+  WithRouter,
+  CreateResourceArgBase,
+  CreateResourceArgSync,
+  CreateResourceArgAsync,
+} from './controllers';
 
 export { RouteComponent, Link } from './ui';
 

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -73,11 +73,18 @@ export type RouteResourceResponse<T> = {|
   accessedAt: RouteResourceTimestamp,
 |};
 
-type ResourceFetchContext = { isPrefetch: boolean };
-export type RouterDataContext = { ...RouterContext, ...ResourceFetchContext };
-
 export type ResourceType = string;
 export type ResourceKey = string;
+
+type ResourceDependencies = {
+  [ResourceType]: RouteResourceResponse<mixed>,
+};
+
+export type RouterDataContext = {
+  ...RouterContext,
+  isPrefetch: boolean,
+  dependencies: ResourceDependencies,
+};
 
 export type GetKey = (
   routerContext: RouterContext,
@@ -95,6 +102,7 @@ export type RouteResourceBase = {|
   maxAge: number,
   maxCache: number,
   isBrowserOnly: boolean,
+  depends: ResourceType[] | null,
 |};
 
 export type RouteResource<T> = {|


### PR DESCRIPTION
```
dependent resources
  executeTuples
    ✓ should throw where there is existing executing state
    ✓ should separately dispatch independent resources without creating executing state
    ✓ should dispatch independent resources even if missing from current route
    ✓ should dispatch independent resources even if missing from current route resources
    ✓ should dispatch independent resources even if current route resources are invalid (null)
    ✓ should dispatch independent resources even if current route resources are invalid (undefined)
    ✓ should dispatch dependent resources as independent if missing from current route resources
    ✓ should dispatch dependent resources as independent if current route resources are invalid (null)
    ✓ should dispatch dependent resources as independent if current route resources are invalid (undefined)
    ✓ should construct an executing state of executing resources and their dependencies
    ✓ should construct an executing state of executing resources and their dependents
    ✓ should construct the smallest executing state of only directly related resources
    ✓ should presume execution mutates executing state and dispatch action from most recent state
    ✓ should remove execution state and throw if executing state is mutated inconsistently
    ✓ should execute independent and dependent resources separately regardless of given tuple order
  executeForDependents
    ✓ should do nothing outside of executing state
    ✓ should do nothing where given resource is not executing
    ✓ should revise action for resources in executing state dependent on the given resource
    ✓ should not revise action for itself where given resource is a self dependent
    ✓ should not revise action for resources preceding the given resource in executing state
  getDependencies
    ✓ should return empty object where given resource has no dependencies
    ✓ should return null where called outside of executing state
    ✓ should throw ResourceDependencyError where given dependent resource is not in executing state
    ✓ should throw ResourceDependencyError for first dependency missing from executing state
    ✓ should return {type:slice} for dependencies preceding given resource in executing state
    ✓ should return {type:own-slice} where given resource is self dependent
    ✓ should throw ResourceDependencyError for first dependency following given resource in executing state


resource store
  dependent resources
    actions on an independent resource where present on on the route
      ✓ request should operate outside of executing state
      ✓ clear should operate outside of executing state
      ✓ update should operate outside of executing state
      ✓ refresh should operate outside of executing state
    actions on dependent resource where present on the route
      ✓ request should operate with executing state
      ✓ clear should operate with executing state
      ✓ update should operate with executing state
      ✓ refresh should operate with executing state
      ✓ request should request dependent resource but not dependency resource
      ✓ refresh should request dependent resource but not dependency resource
      ✓ clear should not clear dependency resource
      ✓ update should not request dependency resource
    actions on dependent resource where omitted from on the route
      ✓ request should operate outside of executing state
      ✓ clear should operate outside of executing state
      ✓ update should operate outside of executing state
      ✓ refresh should operate outside of executing state
      ✓ request should fail with ResourceDependencyError
      ✓ refresh should fail with ResourceDependencyError
    actions on depended resource where there is dependent resource on the route
      ✓ request should operate with executing state
      ✓ clear should operate with executing state
      ✓ update should operate with executing state
      ✓ refresh should operate with executing state
      ✓ request returning promise should request dependent resource with dependency loading
      ✓ refresh returning promise should request dependent resource with dependency loading
      ✓ request returning new value should request dependent resource with dependency loading
      ✓ refresh returning new value should request dependent resource with dependency loading
      ✓ request returning prev value should not request dependent resource
      ✓ refresh returning prev value should not request dependent resource
      ✓ clear should clear dependent resource
      ✓ update new value should request dependent resource with dependency not loading
      ✓ update prev value should request dependent resource with dependency not loading
  
```